### PR TITLE
fixed download links for Mac and Linux

### DIFF
--- a/src/Download/Download.js
+++ b/src/Download/Download.js
@@ -63,14 +63,14 @@ const Download = () => {
             <div className="download-links-box">
                 <div className="flex w-3/12 items-center justify-center">
                     <div className="os-type text-2xl m-4 w-1/2 text-center">Mac</div>
-                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=1lHRB4EOvokiN0LybZw75ij7rI1a_WWZ9', '_blank')} className="download-button-color hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
+                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=16VfzKKgn0-ovhCNBRn_mReedXgiNuufq', '_blank')} className="download-button-color hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
                          <a>Download</a>
                     </button>
                 </div>
 
                 <div className="flex w-3/12 items-center justify-center">
                     <div className="os-type text-2xl m-4 w-1/2 text-center">Linux</div>
-                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=1lHRB4EOvokiN0LybZw75ij7rI1a_WWZ9', '_blank')} className="download-button-color bg-blue-500 hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
+                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=18F880rXGTLcKoBRBpJhsoQprRQiHl6Y9', '_blank')} className="download-button-color bg-blue-500 hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
                          <a>Download</a>
                     </button>
                 </div>

--- a/src/Home/Home.js
+++ b/src/Home/Home.js
@@ -90,14 +90,14 @@ const Home = () => {
             <div className="download-links-box">
                 <div className="flex w-3/12 items-center justify-center">
                     <div className="os-type text-2xl m-4 w-1/2 text-center">Mac</div>
-                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=1lHRB4EOvokiN0LybZw75ij7rI1a_WWZ9', '_blank')} className="download-button-color hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
+                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=16VfzKKgn0-ovhCNBRn_mReedXgiNuufq', '_blank')} className="download-button-color hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
                          <a>Download</a>
                     </button>
                 </div>
 
                 <div className="flex w-3/12 items-center justify-center">
                     <div className="os-type text-2xl m-4 w-1/2 text-center">Linux</div>
-                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=1lHRB4EOvokiN0LybZw75ij7rI1a_WWZ9', '_blank')} className="download-button-color bg-blue-500 hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
+                    <button onClick={ () => window.open('https://drive.google.com/uc?export=download&id=18F880rXGTLcKoBRBpJhsoQprRQiHl6Y9', '_blank')} className="download-button-color bg-blue-500 hover:bg-dark-purple text-white font-bold py-2 px-4 rounded m-4">
                          <a>Download</a>
                     </button>
                 </div>


### PR DESCRIPTION
This change resolves #15

The download links for Mac and Linux have been fixed.

I used the most recent version of the game via the [BytesOfLove Repo](https://github.com/ufosc/VisualNovel) to generate these links in Ren'Py and uploaded them to Google Drive, where they can now be downloaded. 

Windows link was not updated as that was not asked, but I can definitely do that if what I've done here is alright.