### PR TITLE
Update download page with Game Engine description

### DIFF
--- a/src/Download/Download.js
+++ b/src/Download/Download.js
@@ -57,6 +57,13 @@ const Download = () => {
             <Navbar />
 
             <div className="download-title">
+                Game Engine
+            </div>     
+            <div>
+                <div className="description-text">BytesOfLove is built using Ren'Py, a popular visual novel engine. Ren'Py allows for rich storytelling experiences through its easy-to-use scripting language and powerful features.</div>
+            </div>
+            
+            <div className="download-title">
                 How to Play
             </div>
 
@@ -95,7 +102,7 @@ const Download = () => {
                         <path strokeLinecap="round" strokeLinejoin="round" d="m9 9 10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163Zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553Z" />
                     </svg>
                 )}
-            </button>            
+            </button>   
 
             <audio ref={audioRef} src="main_menu.mp3" loop />
         </div>


### PR DESCRIPTION
Updated the download page with a description of the game engine (Ren'py)

- Used styles from `Home.css` to maintain consistency with the existing page styles

This change addresses #25, which was dependent on #28. I noticed that @jonana-split has recently solved #28, so that's why I'm submitting this pull request. 