### PR TITLE
Issue 38: Create Custom Themed Right-Side Scrollbar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,29 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+::-webkit-scrollbar {
+  width: 13px;
+  height: 12px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #6b00719f;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover{
+  background-color: #6b0071b2;
+}
+
+::-webkit-scrollbar-track {
+  background-color: rgb(255, 211, 244);
+}
+/* Alternate scrollbar for browsers that dont support webkit such as firefox */
+@supports not (-webkit-text-stroke: chocolate){
+  * {
+    scrollbar-width:auto; 
+    scrollbar-color: #6b00719f rgb(255, 211, 244);
+  } 
+}
+


### PR DESCRIPTION
# Fixes issue #38

## Changes made:
- Added a custom themed scrollbar that matches the them of the website
- Created an alternative version for browsers that do not support webkit scrollbars such as Mozilla Firefox.
- Added hover effect that darkens the scrollbar thumb
- Made the scrollbar a width that allows it to be seen yet doesn't take up too much space

## Files changed:
- index.css
   -  Made changes here so that they can work throughout multiple components of the website such as in the home page, about, etc.