### PR TITLE
Center-aligned contributor names on about page

### DIFF
--- a/src/About/About.css
+++ b/src/About/About.css
@@ -24,6 +24,7 @@
   margin-top: 2.5vh;
   margin-bottom: 5vh;
   flex-wrap: wrap;
+  text-align: center;
 }
 
 .credit-cell {


### PR DESCRIPTION
Fixed issue that previously made contributor names on About page left-aligned when window size was reduced.
![Screenshot 2024-10-02 at 11 36 46 PM](https://github.com/user-attachments/assets/93870740-98e4-405d-b642-29abdb20083f)
